### PR TITLE
Handle paths with spaces

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
 
 
 build:
-  number: 2
+  number: 3
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
   missing_dso_whitelist:    # [win]

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -5,20 +5,19 @@ REM older than 2.1.0. Copy the appropriate file as the menu file.
 
 SET LOGFILE="%PREFIX%\.messages.txt"
 
-FOR /F "/delims=" %%i IN (
-    '"%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
-) DO (
-    IF "%%~i"=="True" GOTO :use_menuinst_v1
-)
+REM Cannot use usual FOR-loop way to assign output of command because
+REM prefixes with spaces in the name cannot be properly escaped.
+"%CONDA_PYTHON_EXE%" -c "import menuinst, sys; sys.exit(1 if tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0) else 0)"
+IF %ERRORLEVEL% == 1 GOTO :use_menuinst_v1
 COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
 GOTO :exit
 
 :use_menuinst_v1:
     COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
     ECHO. >> %LOGFILE%
-    ECHO Warning: using menuinst v1 shortcuts. >> "%LOGFILE%"
-    ECHO menuinst v1 is marked as legacy and is no longer maintained. >> "%LOGFILE%"
-    ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> "%LOGFILE%"
+    ECHO Warning: using menuinst v1 shortcuts. >> %LOGFILE%
+    ECHO menuinst v1 is marked as legacy and is no longer maintained. >> %LOGFILE%
+    ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> %LOGFILE%
     GOTO :exit
 
 :exit

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -3,22 +3,22 @@
 REM The menuinst v2 json file is not compatible with menuinst versions
 REM older than 2.1.0. Copy the appropriate file as the menu file.
 
-SET LOGFILE=%PREFIX%\.messages.txt
+SET LOGFILE="%PREFIX%\.messages.txt"
 
-FOR /F %%i IN (
-    '%CONDA_PYTHON_EXE% -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
+FOR /F "/delims=" %%i IN (
+    '"%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
 ) DO (
     IF "%%~i"=="True" GOTO :use_menuinst_v1
 )
-COPY /y %PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak %PREFIX%\Menu\%PKG_NAME%_menu.json
+COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
 GOTO :exit
 
 :use_menuinst_v1:
-    COPY /y %PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak %PREFIX%\Menu\%PKG_NAME%_menu.json
+    COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
     ECHO. >> %LOGFILE%
-    ECHO Warning: using menuinst v1 shortcuts. >> %LOGFILE%
-    ECHO menuinst v1 is marked as legacy and is no longer maintained. >> %LOGFILE%
-    ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> %LOGFILE%
+    ECHO Warning: using menuinst v1 shortcuts. >> "%LOGFILE%"
+    ECHO menuinst v1 is marked as legacy and is no longer maintained. >> "%LOGFILE%"
+    ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> "%LOGFILE%"
     GOTO :exit
 
 :exit


### PR DESCRIPTION
git 2.40.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/git/git)

### Explanation of changes:

- Add quotes around paths for installation paths with spaces on Windows.
- Use exit code since the for-loop structure does not work for paths with spaces.