### PR TITLE
Use `%CONDA_ROOT_PREFIX%` as an additional fallback location for `menuinst`

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 7za x PortableGit-%PKG_VERSION%-%ARCH%-bit.7z.exe -o"%LIBRARY_PREFIX%\" -aoa
 if errorlevel 1 exit 1
 
-cd %LIBRARY_PREFIX%
+cd "%LIBRARY_PREFIX%"
 call post-install.bat
 del git_bash.exe
 del git_cmd.exe
@@ -15,16 +15,16 @@ REM menu file so that conda picks it up when running menuinst.
 SET "MENU_DIR=%PREFIX%\Menu"
 IF NOT EXIST "%MENU_DIR%" MKDIR "%MENU_DIR%"
 if errorlevel 1 exit 1
-copy "%RECIPE_DIR%\menu-v1.json" "%PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak"
+copy "%RECIPE_DIR%\menu-v1.json" "%MENU_DIR%\%PKG_NAME%_menu-v1.json.bak"
 if errorlevel 1 exit 1
-copy "%RECIPE_DIR%\menu-v2.json" "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak"
+copy "%RECIPE_DIR%\menu-v2.json" "%MENU_DIR%\%PKG_NAME%_menu-v2.json.bak"
 if errorlevel 1 exit 1
-copy "%RECIPE_DIR%\menu-v2.json" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
+copy "%RECIPE_DIR%\menu-v2.json" "%MENU_DIR%\%PKG_NAME%_menu.json"
 if errorlevel 1 exit 1
 copy "%RECIPE_DIR%\git-for-windows.ico" "%PREFIX%\Menu\"
 if errorlevel 1 exit 1
 
 echo export PATH=$(cygpath -a %PREFIX:\=/%)/Library/bin:$PATH >> %LIBRARY_PREFIX%\etc\profile.d\env.sh
-echo. >> %LIBRARY_PREFIX%\etc\profile.d\env.sh
+echo. >> "%LIBRARY_PREFIX%\etc\profile.d\env.sh"
 
 exit 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,15 +8,21 @@ del git_cmd.exe
 del README.portable
 del post-install.bat
 
-REM Prepare shortcuts. menuinst v2 shortcuts should only be used startings
+REM Prepare shortcuts. menuinst v2 shortcuts should only be used starting
 REM at menuinst v2.1.1 due to bugs. The post-link script
 REM will handle which shortcut to use. One file needs to be the default
 REM menu file so that conda picks it up when running menuinst.
-IF NOT EXIST %PREFIX%\Menu mkdir %PREFIX%\Menu
-copy %RECIPE_DIR%\menu-v1.json %PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak
-copy %RECIPE_DIR%\menu-v2.json %PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak
-copy %RECIPE_DIR%\menu-v2.json %PREFIX%\Menu\%PKG_NAME%_menu.json
-copy %RECIPE_DIR%\git-for-windows.ico %PREFIX%\Menu\
+SET "MENU_DIR=%PREFIX%\Menu"
+IF NOT EXIST "%MENU_DIR%" MKDIR "%MENU_DIR%"
+if errorlevel 1 exit 1
+copy "%RECIPE_DIR%\menu-v1.json" "%PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak"
+if errorlevel 1 exit 1
+copy "%RECIPE_DIR%\menu-v2.json" "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak"
+if errorlevel 1 exit 1
+copy "%RECIPE_DIR%\menu-v2.json" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
+if errorlevel 1 exit 1
+copy "%RECIPE_DIR%\git-for-windows.ico" "%PREFIX%\Menu\"
+if errorlevel 1 exit 1
 
 echo export PATH=$(cygpath -a %PREFIX:\=/%)/Library/bin:$PATH >> %LIBRARY_PREFIX%\etc\profile.d\env.sh
 echo. >> %LIBRARY_PREFIX%\etc\profile.d\env.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
 
 
 build:
-  number: 1
+  number: 2
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
   missing_dso_whitelist:    # [win]

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -3,9 +3,9 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 REM The menuinst v2 json file is not compatible with menuinst versions
 REM older than 2.1.1. Copy the appropriate file as the menu file.
 
-SET LOGFILE=%PREFIX%\.messages.txt
-SET MENU_DIR=%PREFIX%\Menu
-SET MENU_PATH=%MENU_DIR%\%PKG_NAME%_menu.json
+SET "LOGFILE=%PREFIX%\.messages.txt"
+SET "MENU_DIR=%PREFIX%\Menu"
+SET "MENU_PATH=%MENU_DIR%\%PKG_NAME%_menu.json"
 
 REM Determine menuinst version.
 REM menuinst in the base environment is used to create the shortcuts,
@@ -42,7 +42,7 @@ IF %ERRORLEVEL% == 0 (
 GOTO :exit
 
 :patch
-    SET TMPMENU=%MENU_DIR%\%PKG_NAME%_menu_tmp.json
+    SET "TMPMENU=%MENU_DIR%\%PKG_NAME%_menu_tmp.json"
     SET FINDREPLACE=%~1
     FOR /f "delims=" %%i IN ('type "%MENU_PATH%"') DO (
         SET s=%%i

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -17,9 +17,13 @@ IF EXIST "%CONDA_PYTHON_EXE%" (
 REM The CONDA_PYTHON_EXE variable is not set for installers, so use conda-standalone.
 IF EXIST "%PREFIX%\_conda.exe" (
     SET PYTHON_CMD="%PREFIX%\_conda.exe" python
-    SET CONDA_STANDALONE=1
     GOTO :get_menuinst
 )
+IF EXIST "%CONDA_ROOT_PREFIX%\_conda.exe" (
+    SET PYTHON_CMD="%CONDA_ROOT_PREFIX%\_conda.exe" python
+    GOTO :get_menuinst
+)
+
 GOTO :use_menuinst_v1
 
 :get_menuinst


### PR DESCRIPTION
git 2.45.2

**Destination channel:** defaults

### Links

- [PKG-8386](https://anaconda.atlassian.net/browse/PKG-8386) 
- [Upstream repository](https://github.com/git/git)

### Explanation of changes:

- For installers, `%PREFIX%\_conda.exe` is only available when the package is installed into the `base` environment. Use `%CONDA_ROOT_PREFIX%` (which points to the base environment) as an additional fallback.
- Improve quoting of variables to handle paths with spaces.

[PKG-8386]: https://anaconda.atlassian.net/browse/PKG-8386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ