### PR TITLE
Rebuild git against pcre2 10.46 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
   missing_dso_whitelist: # [win]


### PR DESCRIPTION
git 2.51.0

**Destination channel:** Defaults

### Links

- [PKG-10074](https://anaconda.atlassian.net/browse/PKG-10074)
- [Upstream repository](https://github.com/git/git/tree/v2.51.0)

### Explanation of changes:

- Increase build number


[PKG-10074]: https://anaconda.atlassian.net/browse/PKG-10074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ