### PR TITLE
Win arm64

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,11 @@
-7za x PortableGit-%PKG_VERSION%-%ARCH%-bit.7z.exe -o"%LIBRARY_PREFIX%\" -aoa
+REM Handle different archive naming between x64 (64-bit) and arm64
+REM For arm64, we use the self-extracting capability because the archive uses
+REM compression methods (BCJ2 for ARM64) that 7za may not support.
+IF "%ARCH%"=="arm64" (
+    PortableGit-%PKG_VERSION%-arm64.7z.exe -o"%LIBRARY_PREFIX%\" -y
+) ELSE (
+    7za x PortableGit-%PKG_VERSION%-%ARCH%-bit.7z.exe -o"%LIBRARY_PREFIX%\" -aoa
+)
 if errorlevel 1 exit 1
 
 cd "%LIBRARY_PREFIX%"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,10 +1,10 @@
 REM Handle different archive naming between x64 (64-bit) and arm64
-REM For arm64, we use the self-extracting capability because the archive uses
+REM We use the self-extracting capability because the archive uses
 REM compression methods (BCJ2 for ARM64) that 7za may not support.
 IF "%ARCH%"=="arm64" (
     PortableGit-%PKG_VERSION%-arm64.7z.exe -o"%LIBRARY_PREFIX%\" -y
 ) ELSE (
-    7za x PortableGit-%PKG_VERSION%-%ARCH%-bit.7z.exe -o"%LIBRARY_PREFIX%\" -aoa
+    PortableGit-%PKG_VERSION%-%ARCH%-bit.7z.exe -o"%LIBRARY_PREFIX%\" -y
 )
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ source:
 
 
 build:
-  number: 1
+  number: 2
   # git hardcodes paths to external utilities (e.g. curl)
   detect_binary_files_with_prefix: true
   missing_dso_whitelist: # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,14 @@ source:
     folder: git-64-bit  # [win64]
     sha256: 151bddf70e1115631e62bb05535b5e6726b3813e1f363953ad6b4e6697d96933  # [win64]
 
+  - url: https://github.com/git-for-windows/git/releases/download/v{{ version }}.windows.1/PortableGit-{{ version }}-arm64.7z.exe  # [win and arm64]
+    folder: .  # [win and arm64]
+    sha256: 0aacd4edf0c1715334a18725a947584652e1b34bddab63ac3f4a82c9f7c78e38  # [win and arm64]
+  # Use this dummy source to tell our Windows signing process which binaries to skip. This is not actually used in the build.
+  - url: https://github.com/git-for-windows/git/releases/download/v{{ version }}.windows.1/Git-{{ version }}-arm64.tar.bz2  # [win and arm64]
+    folder: git-arm64  # [win and arm64]
+    sha256: 5c3bc6ca50ef6a7686832d2549e6e1b3b1060cf18322a2bbe064d4aec2f33904  # [win and arm64]
+
 
 build:
   number: 1
@@ -42,7 +50,7 @@ requirements:
     - {{ compiler('c') }}  # [unix]
     - autoconf             # [unix]
     - make                 # [unix]
-    - 7zip                 # [win]
+    - 7zip                 # [win64]
   host:
     # https://github.com/git/git/blob/v2.51.0/INSTALL#L110
     - gettext {{ gettext }}    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,6 @@ requirements:
     - {{ compiler('c') }}  # [unix]
     - autoconf             # [unix]
     - make                 # [unix]
-    - 7zip                 # [win64]
   host:
     # https://github.com/git/git/blob/v2.51.0/INSTALL#L110
     - gettext {{ gettext }}    # [unix]


### PR DESCRIPTION
git rebuild with win-arm64 support

**Destination channel:**  defaults

### Links

- [PKG-15371](https://anaconda.atlassian.net/browse/PKG-15371) 


### Explanation of changes:

- Bump build number
- Add correct sources for win-arm64
- 7zip on arm doesn't handle extracting on win-arm64, just use the self-extracting already present. 


[PKG-15371]: https://anaconda.atlassian.net/browse/PKG-15371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ